### PR TITLE
use external (py)dcm2niix package

### DIFF
--- a/niftypet/nimpa/prc/imio.py
+++ b/niftypet/nimpa/prc/imio.py
@@ -1,6 +1,5 @@
 """image input/output functionalities."""
 import datetime
-import glob
 import logging
 import os
 import pathlib
@@ -943,9 +942,11 @@ def dcm2nii(
             fimout += time_stamp(simple_ascii=True)
     fimout = fimout.split('.nii')[0]
 
-    dicom2nifti.convert_directory(dcmpth, opth)
-    # TODO: add fimout prefix
-    fniiout = glob.glob(os.path.join(opth, '*' + fimout + '*.nii*'))
+    fniiout = []
+    for fnii in map(pathlib.Path, dicom2nifti.convert_directory(dcmpth, opth)):
+        dest = fnii.parent / (fimout + fnii.name)
+        fnii.rename(dest)
+        fniiout.append(str(dest))
 
     if fniiout:
         return fniiout[0]

--- a/niftypet/nimpa/prc/imio.py
+++ b/niftypet/nimpa/prc/imio.py
@@ -939,12 +939,16 @@ def dcm2nii(
     else:
         try:
             executable = rs.DCM2NIIX
-        except AttributeError:
-            if tool != 'auto':
-                raise AttributeError("could not find `DCM2NIIX` in resources.py")
-            tool = 'dicom2nifti'
-        else:
             tool = 'dcm2niix'
+        except AttributeError:
+            try:
+                import dcm2niix
+                executable = dcm2niix.bin
+                tool = 'dcm2niix'
+            except ImportError:
+                if tool != 'auto':
+                    raise AttributeError("could not find `DCM2NIIX` in resources.py")
+                tool = 'dicom2nifti'
 
     if not os.path.isdir(dcmpth):
         raise IOError("the provided `dcmpth` is not a folder")

--- a/niftypet/nimpa/prc/prc.py
+++ b/niftypet/nimpa/prc/prc.py
@@ -8,7 +8,6 @@ import os
 import pathlib
 import re
 import sys
-from glob import glob
 from subprocess import run
 from textwrap import dedent
 from warnings import warn
@@ -637,7 +636,6 @@ def pvc_iyang(
                 is needed for co-registration to PET if affine is not given in the text
                 file with its path in faff.
         Cnt:    a dictionary of paths for third-party tools:
-                * dcm2niix: Cnt['DCM2NIIX']
                 * niftyreg, resample: Cnt['RESPATH']
                 * niftyreg, rigid-reg: Cnt['REGPATH']
         pvcroi: list of regions (also a list) with number label to distinguish
@@ -1384,11 +1382,7 @@ def mr2pet_rigid(fpet, mridct, Cnt, outpath='', fcomment='', rmsk=True, rfwhm=15
     elif 'T1bc' in mridct and os.path.isfile(mridct['T1bc']):
         ft1w = mridct['T1bc']
     elif 'T1DCM' in mridct and os.path.exists(mridct['MRT1W']):
-        # create file name for the converted NIfTI image
-        fnii = 'converted'
-        run([Cnt['DCM2NIIX'], '-f', fnii, mridct['T1nii']])
-        ft1nii = glob(os.path.join(mridct['T1nii'], '*converted*.nii*'))
-        ft1w = ft1nii[0]
+        ft1w = imio.dcm2nii(mridct['T1nii'], 'converted')
     else:
         raise ValueError('disaster: no T1w image!')
 

--- a/niftypet/nimpa/prc/prc.py
+++ b/niftypet/nimpa/prc/prc.py
@@ -636,6 +636,7 @@ def pvc_iyang(
                 is needed for co-registration to PET if affine is not given in the text
                 file with its path in faff.
         Cnt:    a dictionary of paths for third-party tools:
+                * dcm2niix: Cnt['DCM2NIIX']
                 * niftyreg, resample: Cnt['RESPATH']
                 * niftyreg, rigid-reg: Cnt['REGPATH']
         pvcroi: list of regions (also a list) with number label to distinguish
@@ -906,15 +907,8 @@ def centre_mass_img(img, output='mm'):
 
 
 # ==============================================================================
-def centre_mass_corr(
-        img,
-        Cnt=None, 
-        com=None,
-        flip=None,
-        outpath=None,
-        fcomment='_com-modified',
-        fout=None):
-
+def centre_mass_corr(img, Cnt=None, com=None, flip=None, outpath=None, fcomment='_com-modified',
+                     fout=None):
     """
     Image centre of mass correction. The O point is in the middle of the
     image centre of voxel value mass (e.g, radio-activity).
@@ -933,7 +927,7 @@ def centre_mass_corr(
     else:
         raise ValueError('unrecognised input image')
 
-    #------------------------------------------------------------------
+    # ------------------------------------------------------------------
     # [optional]
     # > applies if requested a radical correction of orientation by flipping
     if flip is not None:
@@ -942,8 +936,7 @@ def centre_mass_corr(
             imdct['im'] = imdct['im'][:, ::flip[0], ::flip[1], ::flip[2]]
         elif dimno == 3:
             imdct['im'] = imdct['im'][::flip[0], ::flip[1], ::flip[2]]
-    #------------------------------------------------------------------
-
+    # ------------------------------------------------------------------
 
     # > check if the dictionary of constants is given
     if Cnt is None:
@@ -1022,7 +1015,7 @@ def centre_mass_corr(
     # get a new NIfTI image for the perturbed MR
     imdata = innii.get_fdata()
     if flip is not None:
-        imdata = imdata[::flip[2],::flip[1],::flip[0],...]
+        imdata = imdata[::flip[2], ::flip[1], ::flip[0], ...]
     newnii = nib.Nifti1Image(imdata, mA, innii.header)
 
     fnew = os.path.join(opth, fnm)
@@ -1306,7 +1299,7 @@ def bias_field_correction(fmr, fimout='', outpath='', fcomment='_N4bias', execut
         outdct.setdefault('fim', [])
         outdct['fim'].append(fn4)
 
-    if len(outdct['fim'])==1:
+    if len(outdct['fim']) == 1:
         outdct['fim'] = outdct['fim'][0]
 
     return outdct
@@ -1382,7 +1375,9 @@ def mr2pet_rigid(fpet, mridct, Cnt, outpath='', fcomment='', rmsk=True, rfwhm=15
     elif 'T1bc' in mridct and os.path.isfile(mridct['T1bc']):
         ft1w = mridct['T1bc']
     elif 'T1DCM' in mridct and os.path.exists(mridct['MRT1W']):
-        ft1w = imio.dcm2nii(mridct['T1nii'], 'converted')
+        ft1w = imio.dcm2nii(mridct['T1nii'], 'converted',
+                            tool='DCM2NIIX' if 'DCM2NIIX' in Cnt else 'dicom2nifti',
+                            executable=Cnt.get('DCM2NIIX', None))
     else:
         raise ValueError('disaster: no T1w image!')
 

--- a/niftypet/nimpa/prc/prc.py
+++ b/niftypet/nimpa/prc/prc.py
@@ -1375,9 +1375,7 @@ def mr2pet_rigid(fpet, mridct, Cnt, outpath='', fcomment='', rmsk=True, rfwhm=15
     elif 'T1bc' in mridct and os.path.isfile(mridct['T1bc']):
         ft1w = mridct['T1bc']
     elif 'T1DCM' in mridct and os.path.exists(mridct['MRT1W']):
-        ft1w = imio.dcm2nii(mridct['T1nii'], 'converted',
-                            tool='DCM2NIIX' if 'DCM2NIIX' in Cnt else 'dicom2nifti',
-                            executable=Cnt.get('DCM2NIIX', None))
+        ft1w = imio.dcm2nii(mridct['T1nii'], 'converted', executable=Cnt.get('DCM2NIIX', None))
     else:
         raise ValueError('disaster: no T1w image!')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ dev=
     pytest-timeout
     pytest-xdist
 plot=miutil[plot]
+dcm2niix=pydcm2niix>1.0.20220115
 
 [flake8]
 max_line_length=99

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ setup_requires=
     miutil[cuda]>=0.4.0
 install_requires=
     cuvec>=2.3.1
-    dicom2nifti @ https://github.com/NiftyPET/dicom2nifti/archive/refs/heads/output_files-rel.zip#egg=dicom2nifti-3.0.0
+    pydcm2niix>=1.0.20220116
     dipy>=1.3.0
     miutil[nii]>=0.4.2
     nibabel>=2.4.0
@@ -68,7 +68,6 @@ dev=
     pytest-timeout
     pytest-xdist
 plot=miutil[plot]
-dcm2niix=pydcm2niix>1.0.20220115
 
 [flake8]
 max_line_length=99

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ setup_requires=
     miutil[cuda]>=0.4.0
 install_requires=
     cuvec>=2.3.1
-    dicom2nifti>=3.0.0
+    dicom2nifti @ https://github.com/NiftyPET/dicom2nifti/archive/refs/heads/output_files-rel.zip#egg=dicom2nifti-3.0.0
     dipy>=1.3.0
     miutil[nii]>=0.4.2
     nibabel>=2.4.0
@@ -59,8 +59,6 @@ install_requires=
     setuptools
     spm12
     # SimpleITK>=1.2.0
-dependency_links=
-    https://github.com/NiftyPET/dicom2nifti/archive/refs/heads/output_files-rel.zip#egg=dicom2nifti-3.0.0
 python_requires=>=3.6
 [options.extras_require]
 dev=

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ setup_requires=
     miutil[cuda]>=0.4.0
 install_requires=
     cuvec>=2.3.1
+    dicom2nifti
     dipy>=1.3.0
     miutil[nii]>=0.4.2
     nibabel>=2.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ setup_requires=
     miutil[cuda]>=0.4.0
 install_requires=
     cuvec>=2.3.1
-    dicom2nifti
+    dicom2nifti>=3.0.0
     dipy>=1.3.0
     miutil[nii]>=0.4.2
     nibabel>=2.4.0
@@ -59,6 +59,8 @@ install_requires=
     setuptools
     spm12
     # SimpleITK>=1.2.0
+dependency_links=
+    https://github.com/NiftyPET/dicom2nifti/archive/refs/heads/output_files-rel.zip#egg=dicom2nifti-3.0.0
 python_requires=>=3.6
 [options.extras_require]
 dev=

--- a/setup.py
+++ b/setup.py
@@ -51,25 +51,12 @@ resources = cs.get_resources()
 # get the current setup, if any
 Cnt = resources.get_setup()
 # check the installation of tools
-chck_tls = tls.check_version(Cnt, chcklst=["RESPATH", "REGPATH", "DCM2NIIX"])
+chck_tls = tls.check_version(Cnt, chcklst=["RESPATH", "REGPATH"])
 
 # -------------------------------------------
 # NiftyPET tools:
 # -------------------------------------------
 if "sdist" not in sys.argv or any(i in sys.argv for i in ["build", "bdist", "wheel"]):
-    # DCM2NIIX
-    if not chck_tls["DCM2NIIX"]:
-        # reply = tls.query_yesno("q> dcm2niix not found.\n   Install it?")
-        # if reply:
-        log.info(
-            dedent("""\
-            --------------------------------------------------------------
-            Installing dcm2niix ...
-            --------------------------------------------------------------"""))
-        Cnt = tls.install_tool("dcm2niix", Cnt)
-    # ---------------------------------------
-
-    # -------------------------------------------
     # NiftyReg
     if not chck_tls["REGPATH"] or not chck_tls["RESPATH"]:
         reply = True

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,25 @@ resources = cs.get_resources()
 # get the current setup, if any
 Cnt = resources.get_setup()
 # check the installation of tools
-chck_tls = tls.check_version(Cnt, chcklst=["RESPATH", "REGPATH"])
+chck_tls = tls.check_version(Cnt, chcklst=["RESPATH", "REGPATH", "DCM2NIIX"])
 
 # -------------------------------------------
 # NiftyPET tools:
 # -------------------------------------------
 if "sdist" not in sys.argv or any(i in sys.argv for i in ["build", "bdist", "wheel"]):
+    # DCM2NIIX
+    if not chck_tls["DCM2NIIX"]:
+        # reply = tls.query_yesno("q> dcm2niix not found.\n   Install it?")
+        # if reply:
+        log.info(
+            dedent("""\
+            --------------------------------------------------------------
+            Installing dcm2niix ...
+            --------------------------------------------------------------"""))
+        Cnt = tls.install_tool("dcm2niix", Cnt)
+    # ---------------------------------------
+
+    # -------------------------------------------
     # NiftyReg
     if not chck_tls["REGPATH"] or not chck_tls["RESPATH"]:
         reply = True


### PR DESCRIPTION
- [x] ~replace `run([resources.DCM2NIIX, ...])` with `dicom2nifti.convert_directory`~
  - automatically creates the output filename (based on DICOM header `SeriesDescription`
  - [x] ensure `imio.dcm2nii` supports `fimout`/`fprefix`/`fcomment`
    - [x] ~`dicom2nifti.convert_directory` doesn't output file name(s)~ https://github.com/icometrix/dicom2nifti/pull/107
    - [x] keep supporting old version via option flag
    - [ ] check dynamic rescaling slope, units (Bq?), etc...
- [x] #23
  - https://github.com/rordenlab/dcm2niix/pull/573

<details><summary>outdated test script</summary>

```python
from pathlib import Path
from subprocess import check_output
from time import time

import dicom2nifti
from miutil import imio, plot
from niftypet.nimpa import resources as rs

dir_in = './umap'
#dcm2niix = str(Path("~/NiftyPET_tools/dcm2niix/bin/dcm2niix").expanduser())
dcm2niix = rs.DCM2NIIX

def clean_dir(pth):
    if pth.is_dir():
        [i.unlink() for i in pth.glob('*.*')]
        pth.rmdir()
    pth.mkdir()
    return str(pth)

dir_out = clean_dir(Path(dir_in + '-dcm2niix'))
tic = time()
check_output([dcm2niix, '-f', 'test', '-o', dir_out, dir_in])
print(f"{time()-tic:.3f} elapsed (dcm2niix)")

dir_out = clean_dir(Path(dir_in + '-dicom2nifti'))
tic = time()
dicom2nifti.convert_directory(dir_in, dir_out)
print(f"{time()-tic:.3f} elapsed (dicom2nifti)")

pth_in = Path(dir_in)
plot.imscroll({i: imio.imread(i) for i in pth_in.parent.glob(pth_in.stem + '-*/*.nii*')})
plot.show()
```

caveat: it's ~5x slower than `dcm2niix` (https://github.com/icometrix/dicom2nifti/issues/102)

</details>

---

- fixes #23